### PR TITLE
feat: extend portal module with external controllers

### DIFF
--- a/src/portal.module.spec.ts
+++ b/src/portal.module.spec.ts
@@ -1,0 +1,61 @@
+import { ServeStaticModule } from '@nestjs/serve-static';
+import { AuthController } from './auth';
+import { ConfigController } from './config';
+import { EnvController } from './env';
+import { HealthController } from './health';
+import { LogoutController } from './logout';
+import { PortalModule } from './portal.module';
+import { DynamicModule, Provider } from '@nestjs/common';
+
+describe('PortalModule', () => {
+  it('should create portal module', () => {
+    const portalModule = PortalModule.create({});
+
+    expect(portalModule.controllers).toStrictEqual([
+      AuthController,
+      HealthController,
+      EnvController,
+      LogoutController,
+      ConfigController,
+    ]);
+  });
+
+  it('should add additional controllers', () => {
+    const testController: any = 'testController';
+    const portalModule = PortalModule.create({
+      additionalControllers: [testController],
+    });
+
+    expect(portalModule.controllers).toContain(testController);
+  });
+
+  it('should add additional providers', () => {
+    const testProvider: Provider = null;
+    const portalModule = PortalModule.create({
+      additionalProviders: [testProvider],
+    });
+
+    expect(portalModule.providers).toContain(testProvider);
+  });
+
+  it('should set frontendDistSources', () => {
+    const expectedPath = 'test';
+
+    const expectedModule = ServeStaticModule.forRoot({
+      rootPath: expectedPath,
+      exclude: ['/rest'],
+    });
+
+    const portalModule = PortalModule.create({
+      frontendDistSources: expectedPath,
+    });
+
+    const serveStaticModule = portalModule.imports.filter((e) => {
+      return (e as DynamicModule).module.name === 'ServeStaticModule';
+    });
+
+    expect(
+      serveStaticModule.map((e) => (e as DynamicModule).providers)
+    ).toStrictEqual([expectedModule.providers]);
+  });
+});

--- a/src/portal.module.ts
+++ b/src/portal.module.ts
@@ -50,12 +50,12 @@ import { HeaderParserService, CookiesService } from './services';
 
 export interface PortalModuleOptions {
   /**
-   * Providers that need to be known to this module, to create an instance of the other controllers, that are added here.
+   * A set of additional controllers to be registered in the module.
    */
   additionalControllers?: any[];
 
   /**
-   * Providers that need to be known to this module, to create an instance of the other providers, that are added here.
+   * A set of additional providers to be registered in the module.
    */
   additionalProviders?: Provider[];
 


### PR DESCRIPTION
Extend module configuration to be able to add additional controllers

Changes:
* Extend PortalModuleOptions with additionalControllers

Refers to:
https://github.com/openmfp/portal-server-lib/issues/18