### PR TITLE
feat: integrate cookie parser into the library as a middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "concurrently": "^8.2.2",
+        "cookie-parser": "1.4.6",
         "eslint": "8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest": "27.9.0",
@@ -61,6 +62,7 @@
         "@nestjs/platform-express": "10.3.0",
         "@nestjs/serve-static": "4.0.0",
         "axios": "1.6.3",
+        "cookie-parser": "1.4.6",
         "express": "4.19.2",
         "rxjs": "7.8.1"
       }
@@ -3683,6 +3685,30 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nestjs/platform-express": "10.3.0",
     "@nestjs/serve-static": "4.0.0",
     "axios": "1.6.3",
+    "cookie-parser": "1.4.6",
     "express": "4.19.2",
     "rxjs": "7.8.1"
   },
@@ -54,6 +55,7 @@
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "concurrently": "^8.2.2",
+    "cookie-parser": "1.4.6",
     "eslint": "8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "27.9.0",

--- a/src/portal.module.ts
+++ b/src/portal.module.ts
@@ -1,4 +1,11 @@
-import { DynamicModule, Logger, Module, Type } from '@nestjs/common';
+import {
+  DynamicModule,
+  Logger,
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  Type,
+} from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 import { Provider } from '@nestjs/common/interfaces/modules/provider.interface';
 import { ForwardReference } from '@nestjs/common/interfaces/modules/forward-reference.interface';
@@ -47,6 +54,7 @@ import {
   ServiceProviderService,
 } from './config';
 import { HeaderParserService, CookiesService } from './services';
+import cookieParser from 'cookie-parser';
 
 export interface PortalModuleOptions {
   /**
@@ -114,7 +122,11 @@ export interface PortalModuleOptions {
 }
 
 @Module({})
-export class PortalModule {
+export class PortalModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(cookieParser()).forRoutes('*');
+  }
+
   static create(options: PortalModuleOptions): DynamicModule {
     let controllers: any[] = [
       AuthController,


### PR DESCRIPTION
Cookie parser is now installed gloabally so from this version owards there is no need to have code like this in the cosuming apps: `app.use(cookieParser());`