### PR TITLE
feat: crd gateway url adjustments

### DIFF
--- a/src/config/context/openmfp-portal-context.service.spec.ts
+++ b/src/config/context/openmfp-portal-context.service.spec.ts
@@ -1,78 +1,166 @@
 import { EnvService } from '../../env/index.js';
 import { OpenmfpPortalContextService } from './openmfp-portal-context.service.js';
-import type { Request } from 'express';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Request } from 'express';
+import process from 'node:process';
 
 describe('OpenmfpPortalContextService', () => {
   let service: OpenmfpPortalContextService;
-  let envServiceMock: jest.Mocked<EnvService>;
+  let envService: EnvService;
+  const originalEnv = process.env;
 
-  beforeEach(() => {
-    envServiceMock = {
+  beforeEach(async () => {
+    process.env = { ...originalEnv };
+
+    const mockEnvService = {
       getDomain: jest.fn(),
-    } as unknown as jest.Mocked<EnvService>;
+    };
 
-    service = new OpenmfpPortalContextService(envServiceMock);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OpenmfpPortalContextService,
+        { provide: EnvService, useValue: mockEnvService },
+      ],
+    }).compile();
+
+    service = module.get<OpenmfpPortalContextService>(
+      OpenmfpPortalContextService,
+    );
+    envService = module.get<EnvService>(EnvService);
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
-    Object.keys(process.env).forEach((key) => {
-      if (key.startsWith('OPENMFP_PORTAL_CONTEXT_')) {
-        delete process.env[key];
-      }
-    });
-    delete process.env.KUBERNETES_GRAPHQL_GATEWAY_API_URL;
+    process.env = originalEnv;
+    jest.clearAllMocks();
   });
 
-  it('should return context values from process.env with camelCase keys', async () => {
-    process.env.OPENMFP_PORTAL_CONTEXT_HELLO_WORLD = '123';
-    process.env.OPENMFP_PORTAL_CONTEXT_ANOTHER_KEY = '456';
-
-    envServiceMock.getDomain.mockReturnValue({
-      domain: 'portal.dev.local',
-      idpName: 'sub',
-    });
-
-    const mockRequest = { hostname: 'portal.dev.local' } as Request;
-    const result = await service.getContextValues(mockRequest);
-
-    expect(result).toEqual(
-      expect.objectContaining({
-        helloWorld: '123',
-        anotherKey: '456',
-      }),
-    );
+  it('should be defined', () => {
+    expect(service).toBeDefined();
   });
 
-  it('should include crdGatewayApiUrl with replaced subdomain', async () => {
-    process.env.KUBERNETES_GRAPHQL_GATEWAY_API_URL =
-      'https://gateway.${org-subdomain}portal.dev.local';
+  describe('getContextValues', () => {
+    it('should extract environment variables with OPENMFP_PORTAL_CONTEXT_ prefix', async () => {
+      process.env.OPENMFP_PORTAL_CONTEXT_API_URL = 'http://api.example.com';
+      process.env.OPENMFP_PORTAL_CONTEXT_USER_NAME = 'testuser';
+      process.env.OPENMFP_PORTAL_CONTEXT_SOME_LONG_VALUE = 'longvalue';
+      process.env.OTHER_ENV_VAR = 'should not be included';
 
-    envServiceMock.getDomain.mockReturnValue({
-      domain: 'portal.dev.local',
-      idpName: 'sub',
+      const mockRequest = {} as Request;
+      jest.spyOn(service, 'addGraphQLGatewayApiUrl').mockImplementation();
+
+      const result = await service.getContextValues(mockRequest);
+
+      expect(result).toEqual({
+        apiUrl: 'http://api.example.com',
+        userName: 'testuser',
+        someLongValue: 'longvalue',
+      });
+      expect(service.addGraphQLGatewayApiUrl).toHaveBeenCalledWith(
+        mockRequest,
+        result,
+      );
     });
 
-    const mockRequest = { hostname: 'sub.portal.dev.local' } as Request;
-    const result = await service.getContextValues(mockRequest);
+    it('should ignore environment variables with empty key names', async () => {
+      process.env.OPENMFP_PORTAL_CONTEXT_ = 'empty';
+      process.env.OPENMFP_PORTAL_CONTEXT_VALID_KEY = 'valid';
 
-    expect(result.crdGatewayApiUrl).toBe(
-      'https://gateway.sub.portal.dev.local',
-    );
+      const mockRequest = {} as Request;
+      jest.spyOn(service, 'addGraphQLGatewayApiUrl').mockImplementation();
+
+      const result = await service.getContextValues(mockRequest);
+
+      expect(result).toEqual({
+        validKey: 'valid',
+      });
+    });
   });
 
-  it('should use empty subdomain if hostname equals org domain', async () => {
-    process.env.KUBERNETES_GRAPHQL_GATEWAY_API_URL =
-      'https://gateway.${org-subdomain}portal.dev.local';
+  describe('addGraphQLGatewayApiUrl', () => {
+    it('should properly format gateway URL when hostname matches domain', () => {
+      const mockRequest = {
+        hostname: 'example.com',
+      } as Request;
 
-    envServiceMock.getDomain.mockReturnValue({
-      domain: 'portal.dev.local',
-      idpName: 'sub',
+      const context = {};
+      process.env.KUBERNETES_GRAPHQL_GATEWAY_API_URL =
+        'https://${org-subdomain}api.${org-name}.example.com';
+
+      jest.spyOn(envService, 'getDomain').mockReturnValue({
+        domain: 'example.com',
+        idpName: 'test-org',
+      });
+
+      service.addGraphQLGatewayApiUrl(mockRequest, context);
+
+      expect(context).toEqual({
+        crdGatewayApiUrl: 'https://api.test-org.example.com',
+      });
     });
 
-    const mockRequest = { hostname: 'portal.dev.local' } as Request;
-    const result = await service.getContextValues(mockRequest);
+    it('should properly format gateway URL when hostname does not match domain', () => {
+      const mockRequest = {
+        hostname: 'subdomain.example.com',
+      } as Request;
 
-    expect(result.crdGatewayApiUrl).toBe('https://gateway.portal.dev.local');
+      const context = {};
+      process.env.KUBERNETES_GRAPHQL_GATEWAY_API_URL =
+        'https://${org-subdomain}api.${org-name}.example.com';
+
+      jest.spyOn(envService, 'getDomain').mockReturnValue({
+        domain: 'example.com',
+        idpName: 'test-org',
+      });
+
+      service.addGraphQLGatewayApiUrl(mockRequest, context);
+
+      expect(context).toEqual({
+        crdGatewayApiUrl: 'https://test-org.api.test-org.example.com',
+      });
+    });
+
+    it('should handle undefined KUBERNETES_GRAPHQL_GATEWAY_API_URL', () => {
+      const mockRequest = {
+        hostname: 'example.com',
+      } as Request;
+
+      const context = {};
+      process.env.KUBERNETES_GRAPHQL_GATEWAY_API_URL = undefined;
+
+      jest.spyOn(envService, 'getDomain').mockReturnValue({
+        domain: 'example.com',
+        idpName: 'test-org',
+      });
+
+      service.addGraphQLGatewayApiUrl(mockRequest, context);
+
+      expect(context).toEqual({
+        crdGatewayApiUrl: undefined,
+      });
+    });
+  });
+
+  describe('toCamelCase', () => {
+    it('should convert snake_case to camelCase', () => {
+      const result = service['toCamelCase']('TEST_SNAKE_CASE_STRING');
+      expect(result).toBe('testSnakeCaseString');
+    });
+
+    it('should handle single word', () => {
+      const result = service['toCamelCase']('SINGLE');
+      expect(result).toBe('single');
+    });
+  });
+
+  describe('capitalizeFirstLetter', () => {
+    it('should capitalize first letter', () => {
+      const result = service['capitalizeFirstLetter']('test');
+      expect(result).toBe('Test');
+    });
+
+    it('should handle empty string', () => {
+      const result = service['capitalizeFirstLetter']('');
+      expect(result).toBe('');
+    });
   });
 });

--- a/src/config/context/openmfp-portal-context.service.ts
+++ b/src/config/context/openmfp-portal-context.service.ts
@@ -38,7 +38,7 @@ export class OpenmfpPortalContextService implements PortalContextProvider {
       process.env.KUBERNETES_GRAPHQL_GATEWAY_API_URL?.replace(
         '${org-subdomain}',
         subDomain,
-      );
+      ).replace('${org-name}', `${org.idpName}`);
   }
 
   private toCamelCase(text: string): string {


### PR DESCRIPTION
- Refactor `addGraphQLGatewayApiUrl` to include `${org-name}` substitution and improve URL formatting logic
- Enhance unit tests for `OpenmfpPortalContextService`
- Add tests for environment variable extraction, URL formatting, and utility methods