### PR TITLE
feat: change the returned domain

### DIFF
--- a/src/auth/auth-token.service.ts
+++ b/src/auth/auth-token.service.ts
@@ -77,7 +77,10 @@ export class AuthTokenService {
       `${currentAuthEnv.clientId}:${currentAuthEnv.clientSecret}`,
     ).toString('base64')}`;
 
-    const redirectUri = body.get('redirect_uri');
+    const redirectUriMsg =
+      body.get('grant_type') === 'authorization_code'
+        ? `Redirect URI: ${body.get('redirect_uri')}`
+        : '';
     const tokenFetchResult = await firstValueFrom(
       this.httpService
         .post<AuthTokenData>(currentAuthEnv.oauthTokenUrl, body, {
@@ -92,7 +95,7 @@ export class AuthTokenService {
             throw new Error(
               `Error response from auth token server: ${e.toString()}.
               ${e.response.data['error']}: ${e.response.data['error_description']}.
-              params.redirect_uri: ${redirectUri}`,
+              ${redirectUriMsg}`,
             );
           }),
         ),

--- a/src/env/env.service.ts
+++ b/src/env/env.service.ts
@@ -172,6 +172,11 @@ export class EnvService {
       );
     }
 
+    // if we have configured the subdomain idp name in the environment, we use it as a baseDomain
+    if (idpName === subDomainIdpName) {
+      baseDomain = `${subDomainIdpName}.${baseDomain}`;
+    }
+
     return {
       idpName,
       baseDomain,


### PR DESCRIPTION
- **Enhance redirect_uri error handling in auth token service** 
- **Refactor tests in env service for better structure and coverage**
- **Introduce logic to handle subdomain-based base domains in env service**

This commit enhances error verbosity and ensures that subdomain configurations and related logic are properly tested and handled in the service modules.

