### PR TITLE
bug: bring back urlSuffix processing

### DIFF
--- a/src/config/luigi/luigi-data/content-configuration-luigi-data.service.ts
+++ b/src/config/luigi/luigi-data/content-configuration-luigi-data.service.ts
@@ -1,8 +1,7 @@
 import { RawServiceProvider } from '../../context/service-provider.js';
 import {
-  ContentConfiguration,
-  LuigiConfigData,
   LuigiAppConfig,
+  LuigiConfigData,
   LuigiNodeDefaults,
 } from '../../model/content-configuration.js';
 import { LuigiNode } from '../../model/luigi.node.js';
@@ -125,6 +124,8 @@ export class ContentConfigurationLuigiDataService implements LuigiDataService {
 
     if (node.url) {
       viewUrl = `${node.url}`;
+    } else if (node.urlSuffix && urlTemplateUrl) {
+      viewUrl = `${urlTemplateUrl}${node.urlSuffix}`;
     }
 
     if (node.children) {

--- a/src/local-nodes/local-nodes.controller.spec.ts
+++ b/src/local-nodes/local-nodes.controller.spec.ts
@@ -194,7 +194,7 @@ describe('LocalNodesController', () => {
 
   const expectedResultFormProcessing = [
     {
-      _preloadUrl: '/#/preload',
+      _preloadUrl: 'http://localhost:8080/#/preload',
       _requiredIFramePermissionsForViewGroup: undefined,
       _userSettingsConfig: {
         groups: {
@@ -212,7 +212,7 @@ describe('LocalNodesController', () => {
             },
             sublabel: 'sublabel',
             title: 'title',
-            viewUrl: 'viewUrl',
+            viewUrl: 'http://localhost:8080/viewUrl',
           },
         },
       },
@@ -230,7 +230,7 @@ describe('LocalNodesController', () => {
       tabNav: true,
       urlSuffix: '/#/global-catalog',
       viewGroup: undefined,
-      viewUrl: undefined,
+      viewUrl: 'http://localhost:8080/#/global-catalog',
       visibleForFeatureToggles: ['!global-catalog'],
     },
     {
@@ -248,7 +248,7 @@ describe('LocalNodesController', () => {
       tabNav: true,
       urlSuffix: '/#/new-global-catalog',
       viewGroup: undefined,
-      viewUrl: undefined,
+      viewUrl: 'http://localhost:8080/#/new-global-catalog',
       visibleForFeatureToggles: ['global-catalog'],
     },
     {
@@ -264,7 +264,7 @@ describe('LocalNodesController', () => {
           pathSegment: ':extClassName',
           urlSuffix: '/#/extensions/:extClassName',
           viewGroup: undefined,
-          viewUrl: undefined,
+          viewUrl: 'http://localhost:8080/#/extensions/:extClassName',
         },
       ],
       context: {},
@@ -282,6 +282,7 @@ describe('LocalNodesController', () => {
     creationTimestamp: undefined,
     name: 'extension-manager',
     contentType: 'json',
+    url: 'http://localhost:8080',
     luigiConfigFragment: {
       data: {
         userSettings: {
@@ -291,7 +292,7 @@ describe('LocalNodesController', () => {
               sublabel: 'sublabel',
               title: 'title',
               icon: 'icon',
-              viewUrl: 'viewUrl',
+              viewUrl: '/viewUrl',
               settings: {
                 option1: {
                   type: 'type',

--- a/src/local-nodes/local-nodes.controller.ts
+++ b/src/local-nodes/local-nodes.controller.ts
@@ -46,11 +46,19 @@ export class LocalNodesController {
     @Body() config: ConfigDto,
     @Res({ passthrough: true }) response: ExpressResponse,
   ): Promise<TransformResult> {
-    const validationResultsErrors = await this.validate(
-      config.contentConfigurations,
-    );
-    if (validationResultsErrors.length) {
-      return { errors: validationResultsErrors };
+    const validationResults =
+      await this.contentConfigurationValidatorService.validateContentConfigurations(
+        config.contentConfigurations,
+      );
+
+    if (
+      validationResults.some(
+        (validationResult) =>
+          validationResult.validationErrors &&
+          validationResult.validationErrors.length,
+      )
+    ) {
+      return { errors: validationResults };
     }
 
     try {
@@ -72,20 +80,5 @@ export class LocalNodesController {
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
-  }
-
-  private async validate(
-    contentConfigurations: ContentConfiguration[],
-  ): Promise<ValidationResult[]> {
-    const validationResults =
-      await this.contentConfigurationValidatorService.validateContentConfigurations(
-        contentConfigurations,
-      );
-
-    return validationResults.filter(
-      (validationResult) =>
-        validationResult.validationErrors &&
-        validationResult.validationErrors.length,
-    );
   }
 }


### PR DESCRIPTION
Bring back urlSuffix processing for local development issues. The functionality can be reverted once go backend returns processed content configuration along with validation results. Refactor validation logic