### PR TITLE
chore: clean providers api

### DIFF
--- a/src/config/config.controller.ts
+++ b/src/config/config.controller.ts
@@ -12,9 +12,11 @@ import {
   EntityContextProviders,
   EntityNotFoundException,
 } from './context/entity-context-provider.js';
-import { FeatureTogglesProvider } from './context/feature-toggles-provider.js';
-import { PortalContextProvider } from './context/portal-context-provider.js';
-import { RequestContextProvider } from './context/request-context-provider.js';
+import {
+  FeatureTogglesProvider,
+  PortalContextProvider,
+  RequestContextProvider,
+} from './context/index.js';
 import { LuigiConfigNodesService } from './luigi/luigi-config-nodes/luigi-config-nodes.service.js';
 import { EntityParams } from './model/entity.js';
 import { PortalConfig } from './model/luigi.node.js';
@@ -81,7 +83,7 @@ export class ConfigController {
       });
 
     const portalContextPromise = this.portalContextProvider
-      .getContextValues(request, response, providersPromise)
+      .getContextValues(request, response)
       .catch((e: Error) => {
         this.logger.error(e);
         return e;

--- a/src/config/context/index.ts
+++ b/src/config/context/index.ts
@@ -1,2 +1,3 @@
 export * from './request-context-provider.js';
 export * from './portal-context-provider.js';
+export * from './feature-toggles-provider.js';

--- a/src/config/context/portal-context-provider.ts
+++ b/src/config/context/portal-context-provider.ts
@@ -5,7 +5,6 @@ export interface PortalContextProvider {
   getContextValues(
     request: Request,
     response: Response,
-    providersPromise: Promise<ServiceProvider[] | Error>,
   ): Promise<Record<string, any>>;
 }
 

--- a/src/config/luigi/luigi-data/content-configuration-luigi-data.service.spec.ts
+++ b/src/config/luigi/luigi-data/content-configuration-luigi-data.service.spec.ts
@@ -176,7 +176,7 @@ describe('ContentConfigurationLuigiDataService', () => {
                       pathSegment: 'home',
                       label: 'Home',
                       url: 'https://example.com/home',
-                      viewGroup: 'main',
+                      viewGroup: 'https://example.com/viewGroup',
                     },
                     {
                       pathSegment: 'about',
@@ -192,11 +192,10 @@ describe('ContentConfigurationLuigiDataService', () => {
 
         const result = await service.getLuigiData(mockProvider, 'en');
 
-        expect(result[0].viewGroup).toContain(
-          'https://app.example.com#https://example.com#main',
-        );
+        expect(result[0].viewGroup).toContain('https://example.com/viewGroup');
         expect(result[0].viewUrl).toBe('https://example.com/home');
         expect(result[1].viewUrl).toBe('https://app.example.com/about');
+        expect(result[1].viewGroup).toBe('https://app.example.com');
       });
 
       it('should process compound children URLs', async () => {

--- a/src/config/luigi/luigi-data/content-configuration-luigi-data.service.spec.ts
+++ b/src/config/luigi/luigi-data/content-configuration-luigi-data.service.spec.ts
@@ -198,6 +198,36 @@ describe('ContentConfigurationLuigiDataService', () => {
         expect(result[1].viewGroup).toBe('https://app.example.com');
       });
 
+      it('should resolve viewGroup only from node url', async () => {
+        const mockProvider: RawServiceProvider = {
+          contentConfiguration: [
+            {
+              luigiConfigFragment: {
+                data: {
+                  nodes: [
+                    {
+                      pathSegment: 'home',
+                      label: 'Home',
+                      url: 'https://example.com/home',
+                    },
+                    {
+                      pathSegment: 'about',
+                      label: 'About',
+                      url: 'about',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        } as any as RawServiceProvider;
+
+        const result = await service.getLuigiData(mockProvider, 'en');
+
+        expect(result[0].viewGroup).toContain('https://example.com');
+        expect(result[1].viewGroup).toBeUndefined();
+      });
+
       it('should process compound children URLs', async () => {
         const mockProvider: RawServiceProvider = {
           contentConfiguration: [

--- a/src/config/luigi/luigi-data/content-configuration-luigi-data.service.ts
+++ b/src/config/luigi/luigi-data/content-configuration-luigi-data.service.ts
@@ -108,16 +108,21 @@ export class ContentConfigurationLuigiDataService implements LuigiDataService {
       viewUrl: string,
       children = [];
 
-    if (node.url && node.viewGroup) {
+    if (node.viewGroup) {
+      viewGroup = node.viewGroup;
+    } else if (
+      urlTemplateUrl &&
+      (node.url || node.urlSuffix) &&
+      !node.isolateView
+    ) {
+      viewGroup = urlTemplateUrl;
+    } else if (node.url) {
       try {
         const nodeUrl = new URL(node.url);
-        viewGroup =
-          urlTemplateUrl + '#' + nodeUrl.origin + '#' + node.viewGroup;
+        viewGroup = nodeUrl.origin;
       } catch (e) {
         console.warn('Invalid URL: ', node.url);
       }
-    } else if (urlTemplateUrl && node.url && !node.isolateView) {
-      viewGroup = urlTemplateUrl;
     }
 
     this.processCompoundChildrenUrls(node.compound, urlTemplateUrl);

--- a/src/local-nodes/local-nodes.controller.spec.ts
+++ b/src/local-nodes/local-nodes.controller.spec.ts
@@ -176,7 +176,6 @@ describe('LocalNodesController', () => {
         )
         .mockResolvedValue(Promise.resolve(validationResults));
 
-      body = mock<ConfigDto>();
       body = {
         language: 'any',
         contentConfigurations: [
@@ -229,7 +228,7 @@ describe('LocalNodesController', () => {
       showBreadcrumbs: false,
       tabNav: true,
       urlSuffix: '/#/global-catalog',
-      viewGroup: undefined,
+      viewGroup: 'http://localhost:8080',
       viewUrl: 'http://localhost:8080/#/global-catalog',
       visibleForFeatureToggles: ['!global-catalog'],
     },
@@ -247,7 +246,7 @@ describe('LocalNodesController', () => {
       showBreadcrumbs: false,
       tabNav: true,
       urlSuffix: '/#/new-global-catalog',
-      viewGroup: undefined,
+      viewGroup: 'http://localhost:8080',
       viewUrl: 'http://localhost:8080/#/new-global-catalog',
       visibleForFeatureToggles: ['global-catalog'],
     },
@@ -263,7 +262,7 @@ describe('LocalNodesController', () => {
           isolateView: false,
           pathSegment: ':extClassName',
           urlSuffix: '/#/extensions/:extClassName',
-          viewGroup: undefined,
+          viewGroup: 'http://localhost:8080',
           viewUrl: 'http://localhost:8080/#/extensions/:extClassName',
         },
       ],


### PR DESCRIPTION
- Refactor `portal-context-provider` to simplify `getContextValues` parameters and improve index exports.
- Refined viewGroup assignment logic to handle various node configurations more effectively.