### PR TITLE
feat: add nodeContext to server responce

### DIFF
--- a/src/config/luigi/luigi-config-nodes/luigi-config-nodes.service.ts
+++ b/src/config/luigi/luigi-config-nodes/luigi-config-nodes.service.ts
@@ -1,6 +1,6 @@
 import {
-  SERVICE_PROVIDER_INJECTION_TOKEN,
   LUIGI_DATA_SERVICE_INJECTION_TOKEN,
+  SERVICE_PROVIDER_INJECTION_TOKEN,
 } from '../../../injection-tokens.js';
 import {
   RawServiceProvider,
@@ -64,6 +64,7 @@ export class LuigiConfigNodesService {
           displayName: rawProvider.displayName,
           creationTimestamp: rawProvider.creationTimestamp,
           nodes: value.nodes,
+          nodeContext: rawProvider.nodeContext,
         });
       }
     }

--- a/src/config/model/luigi.node.ts
+++ b/src/config/model/luigi.node.ts
@@ -1,6 +1,7 @@
 import { BreadcrumbBadge } from './breadcrumb-badge.js';
 import { LuigiUserSettings } from './luigi-user-settings.js';
 
+
 export interface LuigiNodeCategory {
   label: string;
   collapsible?: boolean;
@@ -158,6 +159,7 @@ export interface ServiceProvider {
   displayName: string;
   creationTimestamp: string;
   nodes: LuigiNode[];
+  nodeContext?: Record<string, any>;
 }
 
 export interface PortalConfig {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service provider entries can now carry node-specific context, improving how configuration data is passed through the app.
  
* **Bug Fixes**
  * Fixed an issue where provider context was not being included in generated node data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->