### PR TITLE
fix: never cache auth-critical responses; explicit static cache policy

### DIFF
--- a/src/middleware/cache-control.middleware.spec.ts
+++ b/src/middleware/cache-control.middleware.spec.ts
@@ -21,7 +21,14 @@ describe('cacheControlNoStore', () => {
     },
   );
 
-  it.each(['/', '/index.html', '/main-ABCD1234.js', '/ui/marketplace/ui/'])(
+  it.each([
+    '/',
+    '/index.html',
+    '/main-ABCD1234.js',
+    '/ui/marketplace/ui/',
+    '/restart',
+    '/restore.png',
+  ])(
     'does not touch caching for %s',
     (path) => {
       cacheControlNoStore(request(path), res, next);

--- a/src/middleware/cache-control.middleware.spec.ts
+++ b/src/middleware/cache-control.middleware.spec.ts
@@ -1,0 +1,32 @@
+import { NextFunction, Request, Response } from 'express';
+import { cacheControlNoStore } from './cache-control.middleware';
+
+describe('cacheControlNoStore', () => {
+  let res: Response;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    res = { setHeader: jest.fn() } as unknown as Response;
+    next = jest.fn();
+  });
+
+  const request = (path: string): Request => ({ path }) as Request;
+
+  it.each(['/rest/config', '/rest/auth', '/rest/config/showroom', '/callback'])(
+    'sets Cache-Control: no-store on %s',
+    (path) => {
+      cacheControlNoStore(request(path), res, next);
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+      expect(next).toHaveBeenCalled();
+    },
+  );
+
+  it.each(['/', '/index.html', '/main-ABCD1234.js', '/ui/marketplace/ui/'])(
+    'does not touch caching for %s',
+    (path) => {
+      cacheControlNoStore(request(path), res, next);
+      expect(res.setHeader).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    },
+  );
+});

--- a/src/middleware/cache-control.middleware.ts
+++ b/src/middleware/cache-control.middleware.ts
@@ -13,7 +13,11 @@ export function cacheControlNoStore(
   res: Response,
   next: NextFunction,
 ): void {
-  if (req.path === '/callback' || req.path.startsWith('/rest')) {
+  if (
+    req.path === '/callback' ||
+    req.path === '/rest' ||
+    req.path.startsWith('/rest/')
+  ) {
     res.setHeader('Cache-Control', 'no-store');
   }
   next();

--- a/src/middleware/cache-control.middleware.ts
+++ b/src/middleware/cache-control.middleware.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from 'express';
+
+/**
+ * Auth-critical API responses must never be cached or revalidated back into
+ * service: a transient 401/500 from /rest/* (config, auth, logout) or
+ * /callback that a browser or shared cache re-serves turns an intermittent
+ * upstream failure into a sticky one that only a hard reload clears
+ * (apeirora/showroom#296). Static assets are handled separately by the
+ * ServeStaticModule cache policy in portal.module.ts.
+ */
+export function cacheControlNoStore(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (req.path === '/callback' || req.path.startsWith('/rest')) {
+    res.setHeader('Cache-Control', 'no-store');
+  }
+  next();
+}

--- a/src/middleware/cache-control.middleware.ts
+++ b/src/middleware/cache-control.middleware.ts
@@ -4,9 +4,9 @@ import { NextFunction, Request, Response } from 'express';
  * Auth-critical API responses must never be cached or revalidated back into
  * service: a transient 401/500 from /rest/* (config, auth, logout) or
  * /callback that a browser or shared cache re-serves turns an intermittent
- * upstream failure into a sticky one that only a hard reload clears
- * (apeirora/showroom#296). Static assets are handled separately by the
- * ServeStaticModule cache policy in portal.module.ts.
+ * upstream failure into a sticky one that only a hard reload clears.
+ * Static assets are handled separately by the ServeStaticModule cache
+ * policy in portal.module.ts.
  */
 export function cacheControlNoStore(
   req: Request,

--- a/src/portal.module.spec.ts
+++ b/src/portal.module.spec.ts
@@ -9,8 +9,9 @@ import { HealthController } from './health/index.js';
 import { PORTAL_CONTEXT_INJECTION_TOKEN } from './injection-tokens.js';
 import { LocalNodesController } from './local-nodes/index.js';
 import { LogoutController } from './logout/index.js';
+import { cacheControlNoStore } from './middleware/cache-control.middleware.js';
 import { PortalModule } from './portal.module.js';
-import { DynamicModule, Provider } from '@nestjs/common';
+import { DynamicModule, MiddlewareConsumer, Provider } from '@nestjs/common';
 import { ServeStaticModule } from '@nestjs/serve-static';
 
 describe('PortalModule', () => {
@@ -123,6 +124,69 @@ describe('PortalModule', () => {
         provide: PORTAL_CONTEXT_INJECTION_TOKEN,
         useClass: CustomPortalContextProvider,
       });
+    });
+  });
+
+  describe('configure', () => {
+    it('should apply the cookie parser and cache-control middleware to all routes', () => {
+      const forRoutes = jest.fn();
+      const consumer = {
+        apply: jest.fn().mockReturnValue({ forRoutes }),
+      } as unknown as MiddlewareConsumer;
+
+      new PortalModule().configure(consumer);
+
+      expect(consumer.apply).toHaveBeenCalledTimes(2);
+      expect(consumer.apply).toHaveBeenCalledWith(cacheControlNoStore);
+      expect(forRoutes).toHaveBeenCalledTimes(2);
+      expect(forRoutes).toHaveBeenCalledWith('*');
+    });
+  });
+
+  describe('static asset cache policy', () => {
+    const setHeadersFor = (path: string) => {
+      const portalModule = PortalModule.create({
+        frontendDistSources: 'test',
+      });
+      const serveStaticModule = portalModule.imports.find(
+        (e) => (e as DynamicModule).module.name === 'ServeStaticModule',
+      ) as DynamicModule;
+      const optionsProvider = serveStaticModule.providers.find(
+        (provider) =>
+          typeof provider === 'object' &&
+          provider !== null &&
+          'useValue' in provider,
+      ) as {
+        useValue: {
+          serveStaticOptions: {
+            setHeaders: (res: any, path: string) => void;
+          };
+        }[];
+      };
+      const res = { setHeader: jest.fn() };
+      optionsProvider.useValue[0].serveStaticOptions.setHeaders(res, path);
+      return res.setHeader;
+    };
+
+    it('should never store html documents', () => {
+      expect(setHeadersFor('/dist/index.html')).toHaveBeenCalledWith(
+        'Cache-Control',
+        'no-store',
+      );
+    });
+
+    it('should cache hashed bundles immutably', () => {
+      expect(setHeadersFor('/dist/main-A1B2C3D4.js')).toHaveBeenCalledWith(
+        'Cache-Control',
+        'public, max-age=31536000, immutable',
+      );
+    });
+
+    it('should revalidate all other assets', () => {
+      expect(setHeadersFor('/dist/assets/logo.svg')).toHaveBeenCalledWith(
+        'Cache-Control',
+        'no-cache',
+      );
     });
   });
 });

--- a/src/portal.module.spec.ts
+++ b/src/portal.module.spec.ts
@@ -51,6 +51,9 @@ describe('PortalModule', () => {
     const expectedModule = ServeStaticModule.forRoot({
       rootPath: expectedPath,
       exclude: ['/rest', '/callback'],
+      serveStaticOptions: {
+        setHeaders: expect.any(Function) as unknown as () => void,
+      },
     });
 
     const portalModule = PortalModule.create({

--- a/src/portal.module.spec.ts
+++ b/src/portal.module.spec.ts
@@ -50,7 +50,7 @@ describe('PortalModule', () => {
 
     const expectedModule = ServeStaticModule.forRoot({
       rootPath: expectedPath,
-      exclude: ['/rest', '/callback'],
+      exclude: ['/rest', '/rest/*path', '/callback'],
       serveStaticOptions: {
         setHeaders: expect.any(Function) as unknown as () => void,
       },

--- a/src/portal.module.ts
+++ b/src/portal.module.ts
@@ -251,9 +251,9 @@ export class PortalModule implements NestModule {
           exclude: ['/rest', '/rest/*path', '/callback'],
           serveStaticOptions: {
             // index.html bootstraps auth — a cached copy can pin a broken
-            // session until a hard reload (apeirora/showroom#296). Hashed
-            // bundles are content-addressed and safe to cache forever;
-            // everything else must revalidate.
+            // session until a hard reload. Hashed bundles are
+            // content-addressed and safe to cache forever; everything else
+            // must revalidate.
             setHeaders: (res, path) => {
               if (path.endsWith('.html')) {
                 res.setHeader('Cache-Control', 'no-store');

--- a/src/portal.module.ts
+++ b/src/portal.module.ts
@@ -248,7 +248,7 @@ export class PortalModule implements NestModule {
       moduleImports.push(
         ServeStaticModule.forRoot({
           rootPath: options.frontendDistSources,
-          exclude: ['/rest', '/callback'],
+          exclude: ['/rest', '/rest/*path', '/callback'],
           serveStaticOptions: {
             // index.html bootstraps auth — a cached copy can pin a broken
             // session until a hard reload (apeirora/showroom#296). Hashed

--- a/src/portal.module.ts
+++ b/src/portal.module.ts
@@ -71,6 +71,8 @@ import {
 import { ServeStaticModule } from '@nestjs/serve-static';
 import cookieParser from 'cookie-parser';
 
+import { cacheControlNoStore } from './middleware/cache-control.middleware.js';
+
 export interface PortalModuleOptions {
   /**
    * A set of additional controllers to be registered in the module.
@@ -150,6 +152,7 @@ export interface PortalModuleOptions {
 export class PortalModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer.apply(cookieParser()).forRoutes('*');
+    consumer.apply(cacheControlNoStore).forRoutes('*');
   }
 
   static create(options: PortalModuleOptions): DynamicModule {
@@ -246,6 +249,24 @@ export class PortalModule implements NestModule {
         ServeStaticModule.forRoot({
           rootPath: options.frontendDistSources,
           exclude: ['/rest', '/callback'],
+          serveStaticOptions: {
+            // index.html bootstraps auth — a cached copy can pin a broken
+            // session until a hard reload (apeirora/showroom#296). Hashed
+            // bundles are content-addressed and safe to cache forever;
+            // everything else must revalidate.
+            setHeaders: (res, path) => {
+              if (path.endsWith('.html')) {
+                res.setHeader('Cache-Control', 'no-store');
+              } else if (/-[A-Z0-9]{8}\.(js|css)$/.test(path)) {
+                res.setHeader(
+                  'Cache-Control',
+                  'public, max-age=31536000, immutable',
+                );
+              } else {
+                res.setHeader('Cache-Control', 'no-cache');
+              }
+            },
+          },
         }),
       );
     }


### PR DESCRIPTION
## Problem

A transient upstream 401/500 on the auth-critical surface can stick until a hard reload: `index.html`, the hashed bundles and `/rest/config` are served with serve-static defaults (`Cache-Control: public, max-age=0` + weak mtime ETags), and API/error responses carry no `Cache-Control` at all — so a browser or shared cache can revalidate a failed response body right back into service. Full analysis with reproduction in apeirora/showroom#296.

## Fix

- new `cacheControlNoStore` middleware: `Cache-Control: no-store` on `/rest/*` and `/callback`, set before the handlers run so success and error responses are covered alike
- explicit static cache policy on `ServeStaticModule`:
  - `index.html` → `no-store` (it bootstraps auth)
  - hashed bundles (`*-XXXXXXXX.js/css`) → `public, max-age=31536000, immutable` (content-addressed)
  - everything else → `no-cache`

## Testing

- new unit spec for the middleware (positive + negative paths)
- `portal.module.spec` updated for the ServeStatic options
- full suite: 30/30 suites, 173/173 tests green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved browser caching for the portal:
    * Authentication/config and callback responses are never cached.
    * HTML pages are always revalidated.
    * Versioned JavaScript/CSS bundles can be cached long-term and immutably.
    * Other static assets use revalidation rather than full caching.
  * Added consistent cache-control behavior across REST and callback traffic.

* **Tests**
  * Added coverage to verify cache-control headers are applied (and not applied) for the expected routes and asset types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->