### PR TITLE
fix: cache-control middleware never matched under Nest's forRoutes('*') — match on originalUrl

### DIFF
--- a/integration-tests/cache-control.integration-spec.ts
+++ b/integration-tests/cache-control.integration-spec.ts
@@ -1,0 +1,31 @@
+import { integrationTestModule } from './integration-test-module.js';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+
+describe('Cache-Control (integration)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture = await integrationTestModule({}).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async function () {
+    await app.close();
+  });
+
+  it('sets no-store on /rest/* through the real middleware mount', () => {
+    return request(app.getHttpServer())
+      .get('/rest/health')
+      .expect(200)
+      .expect('Cache-Control', 'no-store');
+  });
+
+  it('does not touch caching outside the auth-critical paths', async () => {
+    const res = await request(app.getHttpServer()).get('/some-frontend-route');
+
+    expect(res.headers['cache-control']).toBeUndefined();
+  });
+});

--- a/src/middleware/cache-control.middleware.spec.ts
+++ b/src/middleware/cache-control.middleware.spec.ts
@@ -10,30 +10,48 @@ describe('cacheControlNoStore', () => {
     next = jest.fn();
   });
 
-  const request = (path: string): Request => ({ path }) as Request;
+  // Plain Express mount (app.use at root): req.path carries the full path.
+  const expressMounted = (path: string): Request =>
+    ({ path, originalUrl: path }) as Request;
 
-  it.each(['/rest/config', '/rest/auth', '/rest/config/showroom', '/callback'])(
-    'sets Cache-Control: no-store on %s',
-    (path) => {
-      cacheControlNoStore(request(path), res, next);
+  // Nest forRoutes('*') mount (Express 5): the matched path moves into
+  // baseUrl, req.path collapses to '/'; only originalUrl keeps the path.
+  const nestMounted = (path: string): Request =>
+    ({ path: '/', baseUrl: path, originalUrl: path }) as Request;
+
+  describe.each([
+    ['express root mount', expressMounted],
+    ["nest forRoutes('*') mount", nestMounted],
+  ])('%s', (_name, mounted) => {
+    it.each([
+      '/rest/config',
+      '/rest/auth',
+      '/rest/config/showroom',
+      '/rest/config?lang=en',
+      '/callback',
+      '/callback?code=abc&state=xyz',
+    ])('sets Cache-Control: no-store on %s', (path) => {
+      cacheControlNoStore(mounted(path), res, next);
       expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
       expect(next).toHaveBeenCalled();
-    },
-  );
+    });
 
-  it.each([
-    '/',
-    '/index.html',
-    '/main-ABCD1234.js',
-    '/ui/marketplace/ui/',
-    '/restart',
-    '/restore.png',
-  ])(
-    'does not touch caching for %s',
-    (path) => {
-      cacheControlNoStore(request(path), res, next);
+    it.each([
+      '/',
+      '/index.html',
+      '/main-ABCD1234.js',
+      '/ui/marketplace/ui/',
+      '/restart',
+      '/restore.png',
+    ])('does not touch caching for %s', (path) => {
+      cacheControlNoStore(mounted(path), res, next);
       expect(res.setHeader).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalled();
-    },
-  );
+    });
+  });
+
+  it('falls back to req.path when originalUrl is absent', () => {
+    cacheControlNoStore({ path: '/rest/config' } as Request, res, next);
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+  });
 });

--- a/src/middleware/cache-control.middleware.ts
+++ b/src/middleware/cache-control.middleware.ts
@@ -7,17 +7,19 @@ import { NextFunction, Request, Response } from 'express';
  * upstream failure into a sticky one that only a hard reload clears.
  * Static assets are handled separately by the ServeStaticModule cache
  * policy in portal.module.ts.
+ *
+ * Path matching must use req.originalUrl: under Nest's forRoutes('*') mount
+ * (Express 5), the matched path moves into req.baseUrl and req.path
+ * collapses to '/', so a req.path check never matches anything.
+ * req.originalUrl keeps the full request path in every mount context.
  */
 export function cacheControlNoStore(
   req: Request,
   res: Response,
   next: NextFunction,
 ): void {
-  if (
-    req.path === '/callback' ||
-    req.path === '/rest' ||
-    req.path.startsWith('/rest/')
-  ) {
+  const path = (req.originalUrl ?? req.path).split('?')[0];
+  if (path === '/callback' || path === '/rest' || path.startsWith('/rest/')) {
     res.setHeader('Cache-Control', 'no-store');
   }
   next();


### PR DESCRIPTION
follow-up to #356: the no-store middleware tests `req.path`, but under Nest 11 / Express 5 `forRoutes('*')` mounts route-scoped middleware so the matched path moves into `req.baseUrl` and `req.path` collapses to `'/'` — the conditions never match, and `/rest/*` and `/callback` are served without `Cache-Control`. Verified on a live deployment and in a minimal repro; the byte-identical shipped function does work under plain `app.use()`, so it is purely the mount context (probe inside the mount shows `{path: "/", baseUrl: "/rest/health", originalUrl: "/rest/health"}`).

fix: evaluate `req.originalUrl` (query stripped, `req.path` fallback) — full path in both mount contexts, proven in the same repro.

tests: unit spec now exercises both mount shapes including the `path: '/'` collapse and query strings; new integration spec through a real Nest app asserts the header on `/rest/health` — it fails without this fix. Full suite: unit 194/194, integration 25/25, middleware at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caching behavior detection across different routing configurations.
  * Ensured auth-critical endpoints consistently return `Cache-Control: no-store`, including requests with query parameters.
  * Prevented caching headers from being added to frontend routes outside protected endpoints.
  * Added coverage for health checks and fallback request-path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->