### PR TITLE
fix: remove undeclared lodash dependency

### DIFF
--- a/src/auth/auth-config.service.ts
+++ b/src/auth/auth-config.service.ts
@@ -1,7 +1,6 @@
 import { DiscoveryService, EnvService } from '../env/index.js';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import type { Request } from 'express';
-import _ from 'lodash';
 
 interface BaseDomainsToIdp {
   idpName: string;
@@ -188,7 +187,7 @@ export class EnvAuthConfigService implements AuthConfigService {
   }
 
   private getBaseDomainRegex(baseDomain: string): RegExp {
-    const domain = _.escapeRegExp(baseDomain);
+    const domain = baseDomain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return new RegExp(`(.*)\\.${domain}`);
   }
 }


### PR DESCRIPTION
## Summary

- Replace `_.escapeRegExp()` with a native regex replacement in `auth-config.service.ts`
- Remove the `lodash` import that was never declared in `package.json` dependencies

## Problem

`lodash` is imported and used in `src/auth/auth-config.service.ts` but is not listed in `dependencies` or `peerDependencies` in `package.json`. This causes a runtime crash (`ERR_MODULE_NOT_FOUND: Cannot find package 'lodash'`) for any consumer that installs with `npm ci --omit=dev`.

The only usage was `_.escapeRegExp(baseDomain)` which is trivially replaceable with a native regex pattern.

## Test plan

- [x] All 18 existing unit tests in `auth-config.service.spec.ts` pass
- [x] Build compiles successfully (`npm run build`)
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal domain pattern handling while preserving existing authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->