### PR TITLE
Fix: remove undeclared lodash dependency

### DIFF
--- a/src/auth/auth-config.service.ts
+++ b/src/auth/auth-config.service.ts
@@ -1,7 +1,6 @@
 import { DiscoveryService, EnvService } from '../env/index.js';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import type { Request } from 'express';
-import _ from 'lodash';
 
 interface BaseDomainsToIdp {
   idpName: string;
@@ -188,7 +187,7 @@ export class EnvAuthConfigService implements AuthConfigService {
   }
 
   private getBaseDomainRegex(baseDomain: string): RegExp {
-    const domain = _.escapeRegExp(baseDomain);
+    const domain = baseDomain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return new RegExp(`(.*)\\.${domain}`);
   }
 }


### PR DESCRIPTION
`lodash` was never declared as a dependency, which causes issues with consuming libraries when calling `npm ci --omit=dev`. I realized that there's only a single part where `lodash` is actually used, so instead of addig `lodash` to the dependency we could remove this depency all together.

The alternative fix would be to just declare it as an depencency, if you're set on including lodash for a single use.