### PR TITLE
fix: declare all runtime dependencies (lodash removal + uri-js)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
         "jwt-decode": "^4.0.0",
+        "uri-js": "^4.4.1",
         "validator": ">=13.15.35"
       },
       "devDependencies": {
@@ -8778,7 +8779,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10334,7 +10334,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "uri-js": "^4.4.1",
     "validator": ">=13.15.35",
     "jwt-decode": "^4.0.0"
   },

--- a/src/auth/auth-config.service.ts
+++ b/src/auth/auth-config.service.ts
@@ -1,7 +1,6 @@
 import { DiscoveryService, EnvService } from '../env/index.js';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import type { Request } from 'express';
-import _ from 'lodash';
 
 interface BaseDomainsToIdp {
   idpName: string;
@@ -188,7 +187,7 @@ export class EnvAuthConfigService implements AuthConfigService {
   }
 
   private getBaseDomainRegex(baseDomain: string): RegExp {
-    const domain = _.escapeRegExp(baseDomain);
+    const domain = baseDomain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return new RegExp(`(.*)\\.${domain}`);
   }
 }


### PR DESCRIPTION
## Summary

- Remove undeclared `lodash` import — replace `_.escapeRegExp()` with native regex in `auth-config.service.ts`
- Add `uri-js` to `dependencies` — it is imported in `content-configuration-luigi-data.service.ts` but was never declared

## Problem

Consumers using `npm ci --omit=dev` (best practice for production Docker images) get runtime crashes:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'lodash' imported from .../auth-config.service.js
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'uri-js' imported from .../content-configuration-luigi-data.service.js
```

These packages are used in source but not declared in `package.json`, so they only resolve accidentally when the full dev dependency tree is installed.

## Changes

1. **`src/auth/auth-config.service.ts`**: Remove `lodash` import, replace `_.escapeRegExp(baseDomain)` with `baseDomain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`
2. **`package.json`**: Add `"uri-js": "^4.4.1"` to `dependencies`

## Test plan

- [x] All unit tests pass (31 tests across auth-config + content-configuration)
- [x] Build compiles successfully
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when validating authentication domains, including domains containing special characters.
* **Chores**
  * Updated supporting runtime components to improve URL and domain handling.
  * Removed unused internal code to streamline authentication processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->