### PR TITLE
fix: add uri-js as declared dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
         "jwt-decode": "^4.0.0",
+        "uri-js": "^4.4.1",
         "validator": ">=13.15.35"
       },
       "devDependencies": {
@@ -8778,7 +8779,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10334,7 +10334,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "uri-js": "^4.4.1",
     "validator": ">=13.15.35",
     "jwt-decode": "^4.0.0"
   },


### PR DESCRIPTION
## Summary

- Adds `uri-js` as a direct dependency in `package.json`

The `uri-js` package is imported in `src/config/luigi/luigi-data/content-configuration-luigi-data.service.ts` but was never declared as a dependency. It only worked transitively through dev dependencies.

When consumers install this library with `npm ci --omit=dev` (as the hyper-portal Dockerfile does), the missing dependency causes a runtime crash:

```
Error: Cannot find module 'uri-js'
```

This is the same class of issue as the recently fixed lodash removal (v0.164.13) — undeclared runtime dependencies that happen to exist transitively during development but break in production installs.